### PR TITLE
Add vaniton, vanity address generation into the new Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,8 @@
 * [ton](https://github.com/ex3ndr/ton) - Typescript-based rewrite of TonWeb
 * [pyTONv3](https://github.com/EmelyanenkoK/pytonv3) - Python-based HTTP API proxy
 
+# Utilities
+* [vaniton](https://github.com/AntonMeep/vaniton) - Vanity address generator for The Open Network's standard wallets
+
 # License
 MIT


### PR DESCRIPTION
This adds a link to [vaniton](https://github.com/AntonMeep/vaniton), as well as a new utilities section.
My proposal is that to this section one could add some of the nifty tools for TON.