### PR TITLE
Add ton-go library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * [TonWeb](https://github.com/toncenter/tonweb) - Browser and NodeJS js library
 * [ton](https://github.com/ex3ndr/ton) - Typescript-based rewrite of TonWeb
 * [pyTONv3](https://github.com/EmelyanenkoK/pytonv3) - Python-based HTTP API proxy
+* [TON Go](https://github.com/bored-ton/ton-go) - Golang client for toncenter HTTP API
 
 # Utilities
 * [vaniton](https://github.com/AntonMeep/vaniton) - Vanity address generator for The Open Network's standard wallets


### PR DESCRIPTION
`ton-go` is the client on go for toncenter HTTP API v2 (currently). 
it would be nice to have in the list